### PR TITLE
Add 404 not found page

### DIFF
--- a/devjobs/pages/404.js
+++ b/devjobs/pages/404.js
@@ -1,0 +1,7 @@
+export default function Custom404() {
+    return (
+        <h1 className="flex justify-center items-center w-full h-screen">
+            404 - Page Not Found
+        </h1>
+    );
+}


### PR DESCRIPTION
404 not found page has been created.
Info: It is sufficient to create a 404.js file under the pages folder to redirect urls that are not found.